### PR TITLE
Make included scripts use protocol-relative paths

### DIFF
--- a/header.php
+++ b/header.php
@@ -10,8 +10,8 @@
     <!-- Asset Links -->
     <link href="<?php echo theme_url('assets/style.css'); ?>" media="screen" rel="stylesheet" type="text/css" />
     <link rel="shortcut icon" href="<?php echo theme_url('assets/favicon.ico'); ?>" type="image/x-icon" />
-    <link href='http://fonts.googleapis.com/css?family=Merriweather:300,400,900|Open+Sans:400,700,800' rel='stylesheet' type='text/css'>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <link href='//fonts.googleapis.com/css?family=Merriweather:300,400,900|Open+Sans:400,700,800' rel='stylesheet' type='text/css'>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
   </head>
   
   <body>


### PR DESCRIPTION
jQuery & Google fonts are blocked if you're connecting via HTTPS.

Rather than hardcode the protocol to use, leaving out "http://" in the `src` attribute in favor of "//" selects the protocol you're currently using to load the page.