### PR TITLE
Fixes missing links when sharing posts via Twitter button

### DIFF
--- a/article.php
+++ b/article.php
@@ -22,8 +22,8 @@
                 
                         <p><?php echo article_markdown(); ?></p>
                     <div class="share">
-                        <a onclick="window.open(this.href, 'mywin','left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" href="http://www.twitter.com/share?url=<?php echo article_url(); ?>&text=<?php echo article_title(); ?><?php if(site_meta('twitter_account')) : ?>&via=<?php echo site_meta('twitter_account') ?><?php endif; ?>"><img src="<?php echo theme_url('assets/img/twitter.png'); ?>" /></a>
-                        <a href="<?php echo article_url(); ?>"><img src="<?php echo theme_url('assets/img/permalink.png'); ?>" /></a>
+                        <a onclick="window.open(this.href, 'mywin','left=20,top=20,width=500,height=500,toolbar=1,resizable=0'); return false;" href="https://www.twitter.com/share?url=<?php echo article_full_url(); ?>&text=<?php echo article_title(); ?><?php if(site_meta('twitter_account')) : ?>&via=<?php echo site_meta('twitter_account') ?><?php endif; ?>"><img src="<?php echo theme_url('assets/img/twitter.png'); ?>" /></a>
+                        <a href="<?php echo article_full_url(); ?>"><img src="<?php echo theme_url('assets/img/permalink.png'); ?>" /></a>
                     </div>
                 </div>
                 <?php if(article_js() | article_css()): ?>

--- a/functions.php
+++ b/functions.php
@@ -51,4 +51,9 @@ function featured_color() {
     return Config::get('meta.color');
 };
 
+function article_full_url() {
+	$page = Registry::get('posts_page');
+	return full_url($page->slug . '/' . article_slug());
+}
+
 ?>


### PR DESCRIPTION
Adds a function to generate full post urls and then passes as the url parameter for the twitter sharing link. This is necessary because the url parameter only accepts absolute paths.
