### PR TITLE
Fix problem Anchor CMS Converting hyphen to underscore

### DIFF
--- a/article.php
+++ b/article.php
@@ -1,8 +1,8 @@
 <?php theme_include('header'); ?>
 <div name="post">
         <div class="post-container">
-            <?php if(article_custom_field('featured-image')) : ?>
-            <div class="featured" style="background-image:url('<?php echo article_custom_field('featured-image')?>')" >
+            <?php if(article_custom_field('featured_image')) : ?>
+            <div class="featured" style="background-image:url('<?php echo article_custom_field('featured_image')?>')" >
             
                 <div id="featured-credit">
                         <a id="credits"></a>

--- a/page.php
+++ b/page.php
@@ -1,8 +1,8 @@
 <?php theme_include('header'); ?>
 <div name="post">
         <div class="post-container">
-            <?php if(page_custom_field('page-featured-image')) : ?>
-            <div class="featured" style="background:url('<?php echo page_custom_field('page-featured-image')?>') " >
+            <?php if(page_custom_field('page_featured_image')) : ?>
+            <div class="featured" style="background:url('<?php echo page_custom_field('page_featured_image')?>') " >
             <?php else: ?>
             <div class="featured" id="<?php echo page_id(); ?>">
             <?php endif; ?>

--- a/posts.php
+++ b/posts.php
@@ -3,8 +3,8 @@
       <div class="primary">
 	<div id="content" role="main">
             <?php if(has_posts()) : while(posts()) : ?>
-		  <?php if(article_custom_field('featured-image')): ?>
-			<article class="post" id="<?php echo article_id(); ?>" style="background-image:url('<?php echo article_custom_field('featured-image') ?>')">
+		  <?php if(article_custom_field('featured_image')): ?>
+			<article class="post" id="<?php echo article_id(); ?>" style="background-image:url('<?php echo article_custom_field('featured_image') ?>')">
 		  <?php elseif(article_custom_field('featured-color')) : ?>
 			<article class="post" id="<?php echo article_id(); ?>" style="background-color:<?php echo article_custom_field('featured-color') ?>">
 		  <?php else : ?>


### PR DESCRIPTION
Anchor CMS tends to change input of the Custom Field from hyphen to underscore. This creates the problem that the theme barhop can't find the input of the user to display the right picture in the posts.php & article.php.

I solved it by changing the php in the theme from hyphens to underscores.

To prevent future problems i also change the page.php file where a similar problem awaited when you want to use the background image of individual page in the header. Here were also hyphens used. I also changed them.